### PR TITLE
Fix format string vulnerabilities

### DIFF
--- a/src/q2a_lua_export.c
+++ b/src/q2a_lua_export.c
@@ -32,7 +32,7 @@ int q2a_lua_gi_bprintf(lua_State *L)
 
 	q2a_fpu_q2();
 
-	gi.bprintf(lvl, str);
+	gi.bprintf(lvl, "%s", str);
 
 	q2a_fpu_lua();
 
@@ -54,7 +54,7 @@ int q2a_lua_gi_cprintf(lua_State *L)
 
 	q2a_fpu_q2();
 
-	gi.cprintf(ent, lvl, str);
+	gi.cprintf(ent, lvl, "%s", str);
 
 	q2a_fpu_lua();
 
@@ -74,7 +74,7 @@ int q2a_lua_gi_centerprintf(lua_State *L)
 
 	q2a_fpu_q2();
 
-	gi.centerprintf(ent, str);
+	gi.centerprintf(ent, "%s", str);
 
 	q2a_fpu_lua();
 

--- a/src/q2a_main.c
+++ b/src/q2a_main.c
@@ -197,76 +197,47 @@ void ServerCommand (void)
 	copyDllInfo();
 }
 
-char *escape_buf(const char *buf)
-{
-	static char out[8192];
-	unsigned int i, pos = 0, len = strlen(buf);
-
-	if (len > (sizeof out / 2) - 1)
-	    len = (sizeof out / 2) - 1;
-
-	for (i = 0; i < len; i++)
-	{
-		if (buf[i] == '%')
-			out[pos++] = '%';
-		out[pos++] = buf[i];
-	}
-
-	out[pos] = '\0';
-
-	return out;
-}
-
 void game_bprintf(int printlevel, char *fmt, ...)
 {
 	va_list args;
-	static char buf[4096];
-	char *safe_buf;
+	char buf[1024];
 
 	va_start(args, fmt);
-	vsnprintf(buf, sizeof buf, fmt, args);
+	vsprintf(buf, fmt, args);
 	va_end(args);
 
 	q2a_lua_LogMessage(buf);
 
-	safe_buf = escape_buf(buf);
-
-	gi.bprintf(printlevel, safe_buf);
+	gi.bprintf(printlevel, buf);
 }
 
 void game_dprintf(char *fmt, ...)
 {
 	va_list args;
-	static char buf[4096];
-	char *safe_buf;
+	char buf[1024];
 
 	va_start(args, fmt);
-	vsnprintf(buf, sizeof buf, fmt, args);
+	vsprintf(buf, fmt, args);
 	va_end(args);
 
 	q2a_lua_LogMessage(buf);
 
-	safe_buf = escape_buf(buf);
-
-	gi.dprintf(safe_buf);
+	gi.dprintf(buf);
 }
 
 void game_cprintf(edict_t *ent, int printlevel, char *fmt, ...)
 {
 	va_list args;
-	static char buf[4096];
-	char *safe_buf;
+	char buf[1024];
 
 	va_start(args, fmt);
-	vsnprintf(buf, sizeof buf, fmt, args);
+	vsprintf(buf, fmt, args);
 	va_end(args);
 
 	if (ent == NULL)
 		q2a_lua_LogMessage(buf);
 
-	safe_buf = escape_buf(buf);
-
-	gi.cprintf(ent, printlevel, safe_buf);
+	gi.cprintf(ent, printlevel, buf);
 }
 
 /*

--- a/src/q2a_main.c
+++ b/src/q2a_main.c
@@ -208,7 +208,7 @@ void game_bprintf(int printlevel, char *fmt, ...)
 
 	q2a_lua_LogMessage(buf);
 
-	gi.bprintf(printlevel, buf);
+	gi.bprintf(printlevel, "%s", buf);
 }
 
 void game_dprintf(char *fmt, ...)
@@ -222,7 +222,7 @@ void game_dprintf(char *fmt, ...)
 
 	q2a_lua_LogMessage(buf);
 
-	gi.dprintf(buf);
+	gi.dprintf("%s", buf);
 }
 
 void game_cprintf(edict_t *ent, int printlevel, char *fmt, ...)
@@ -237,7 +237,7 @@ void game_cprintf(edict_t *ent, int printlevel, char *fmt, ...)
 	if (ent == NULL)
 		q2a_lua_LogMessage(buf);
 
-	gi.cprintf(ent, printlevel, buf);
+	gi.cprintf(ent, printlevel, "%s", buf);
 }
 
 /*


### PR DESCRIPTION
This fixes the format string holes both in the wrapper functions (called by the game DLL) and in the functions exported to Lua.
